### PR TITLE
move additional links from tfoot to end of site

### DIFF
--- a/template.html
+++ b/template.html
@@ -46,12 +46,13 @@
 			padding: 0;
 			padding-bottom: 1em;
 		}
-		tfoot {
-			font-size: small;
-		}
 		tfoot p {
 			margin: 0;
 		}
+		.notes {
+			font-size: small;
+			padding-bottom: 0;
+			}
 		@media print {
 			form {
 				display: none;
@@ -95,7 +96,7 @@
 		</tbody>
 		<tfoot>
 			<tr>
-				<td class="fake-td">
+				<td class="fake-td notes">
 					<p>Die mit einem * markierten Begriffe haben wir mit freundlicher
 					Genehmigung der Schwulenberatung Berlin gGmbH aus ihrer
 					<a href="https://schwulenberatungberlin.de/post/handreichung-fuer-dolmetscher-innen/">Handreichung für Dolmetscher*innen</a> entnommen.</p>
@@ -103,7 +104,7 @@
 			</tr>
 		</tfoot>
 	</table>
-	<div>
+	<div class="notes">
 		<p>Das Glossar der KuB wird ständig überarbeitet und regelmäßig auf
 		<a href="https://kub-berlin.org/ueber-die-kub/veroeffentlichungen/">der Webseite</a>
 		veröffentlicht.</p>

--- a/template.html
+++ b/template.html
@@ -46,12 +46,12 @@
 			padding: 0;
 			padding-bottom: 1em;
 		}
-		tfoot p {
-			margin: 0;
-		}
 		.notes {
 			font-size: small;
 			padding-bottom: 0;
+			}
+		.notes p {
+			margin: 0;
 			}
 		@media print {
 			form {

--- a/template.html
+++ b/template.html
@@ -96,19 +96,19 @@
 		<tfoot>
 			<tr>
 				<td class="fake-td">
-					<p>Das Glossar der KuB wird ständig überarbeitet und regelmäßig auf
-					<a href="https://kub-berlin.org/ueber-die-kub/veroeffentlichungen/">der Webseite</a>
-					veröffentlicht.</p>
-
 					<p>Die mit einem * markierten Begriffe haben wir mit freundlicher
 					Genehmigung der Schwulenberatung Berlin gGmbH aus ihrer
 					<a href="https://schwulenberatungberlin.de/post/handreichung-fuer-dolmetscher-innen/">Handreichung für Dolmetscher*innen</a> entnommen.</p>
-
-					<p>Es gibt auch ein <a href="https://www.bamf.de/SharedDocs/Anlagen/DE/EMN/Glossary/emn-glossary2.html">Glossar des Europäischen Migrationsnetzwerks (EMN)</a> mit vielen Wörtern und Übersetzungen in allen EU-Sprachen.</p>
 				</td>
 			</tr>
 		</tfoot>
 	</table>
+	<div>
+		<p>Das Glossar der KuB wird ständig überarbeitet und regelmäßig auf
+		<a href="https://kub-berlin.org/ueber-die-kub/veroeffentlichungen/">der Webseite</a>
+		veröffentlicht.</p>
+		<p>Es gibt auch ein <a href="https://www.bamf.de/SharedDocs/Anlagen/DE/EMN/Glossary/emn-glossary2.html">Glossar des Europäischen Migrationsnetzwerks (EMN)</a> mit vielen Wörtern und Übersetzungen in allen EU-Sprachen.</p>
+	</div>
 
 	<script>
 		var form = document.createElement('form');


### PR DESCRIPTION
The links to the KuB Website and to the glossary of EMN should not appear on every printed page but only once at the end of the document.