### PR TITLE
migrate to new transifex client

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[buro.glossar]
+[o:kub:p:buro:r:glossar]
 source_file = data/de.csv
 source_lang = de
 type = MAGENTO


### PR DESCRIPTION
see https://github.com/transifex/cli

TL;DR: most commands still work as before.

$HOME/.transifex needs to be adapted (see https://docs.transifex.com/client/introduction)

I this is merged I will apply the same change also in the other repos.