### PR TITLE
automatically update glossar.html on server 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: "latest"
         allowUpdates: true
+
+    - name: notify the website about the new version
+      run: curl https://kub-berlin.org/glossar/update.php

--- a/gen_csp.sh
+++ b/gen_csp.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles
+# save as .htaccess
+
+extract() {
+	open=0
+	while IFS= read -r line; do
+		if [ "$line" = "	<$1>" ]; then
+			open=1
+			printf "\n"
+		elif [ "$line" = "	</$1>" ]; then
+			open=0
+			printf "	"
+		elif [ "$open" = 1 ]; then
+			echo "$line"
+		fi
+	done < template.html
+}
+
+stylesrc=$(extract 'style' | openssl dgst -sha256 -binary | openssl enc -base64)
+scriptsrc=$(extract 'script' | openssl dgst -sha256 -binary | openssl enc -base64)
+
+echo '<Files "*.*">'
+echo "Header set Content-Security-Policy \"default-src 'self'; style-src 'sha256-$stylesrc'; script-src 'sha256-$scriptsrc'\""
+echo '</Files>'

--- a/update.php
+++ b/update.php
@@ -1,0 +1,2 @@
+<?php
+copy('https://github.com/kub-berlin/glossar/releases/download/latest/glossar.html', 'index.html')


### PR DESCRIPTION
works in tandem with #3

## security considerations

`glossar-update.php` will copy a file from this repository to the server. This allows to attacks:

- An attacker can make repeated requests to that script which will trigger and potentially create so much load that our server crashes (denial of service). However I don't think that the script is worse that your common CMS. Our hosters usual DDoS protection should be sufficient protection.
- If an attacker gains write access to this repository, they can replace `glossar.html` with an arbitrary file that is then uploaded to our server. Since the filename is hardcoded to be `*.html` this will not be interpreted as PHP code (and therefore not give the attacker arbitrary code execution on the server) but they can still include JavaScript which gives them quite a bit to work with. They could also use a very large file could again result in a denial of service. This could be prevented by including heutistics in the PHP script. I am still looking into that. But of course, getting write access to the repo is not easy in the first place.

  **update**: I added a script that will generate a Content-Security-Policy with hashes so that browser will not execute any CSS or JavaScript code other than what we explicitly allowed. This Content-Security-Policy will not be updated automatically. Since there are now three files (`glossary.html`, `update.php`, `.htaccess`) I think we should have a subdirectory on the server.