### PR TITLE
Revert "configure transifex integration"

### DIFF
--- a/.tx/integration.yml
+++ b/.tx/integration.yml
@@ -1,7 +1,0 @@
-git:
-  filters:
-    - filter_type: file
-      source_file: data/de.csv
-      source_language: de
-      file_format: MAGENTO
-      translation_files_expression: 'data/<lang>.csv'


### PR DESCRIPTION
Reverts kub-berlin/glossar#3

See #6 #7 #8 #9 for examples.

I toyed with this and came to the conclusion that it is not a perfect fit and working around the issues is not worth the effort. I think we should continue to sync the translations manually. The main issues are:

- A pull request is only created when 100% of the strings have been created, which is rarely the case with our data.
- I am not sure, but I believe that changes to the source file will automatically sync to transifex. There is no way to disable that. This has a lot of potential for disaster, so I would prefer not to have that.
- This adds significant complexity