### PR TITLE
run tx pull in weekly github action

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -1,0 +1,28 @@
+on:
+  schedule:
+    - cron:  '0 0 * * 0'  # every sunday at 0:00 UTC
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install transifex client
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: transifex/cli
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: run tx pull
+      run: tx --token ${{ secrets.TRANSIFEX_TOKEN }} pull -f
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'tx pull [automated]'
+        title: 'tx pull [automated]'
+        branch: 'tx-pull'
+        delete-branch: true


### PR DESCRIPTION
Alternative to https://github.com/kub-berlin/glossar/pull/3

Instead of using the integration, I used a github action that combines some simple tools:

- Install the transifex client from github
- Pull all translations (using a transifex token I added to github)
- Create a pull request using [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) (example: https://github.com/kub-berlin/glossar/pull/12)
- Run all that once peer week (Sunday 0:00)

To me this feels solid and much clearer than #3.