### PR TITLE
fix: keep table header in search result

### DIFF
--- a/template.html
+++ b/template.html
@@ -119,7 +119,7 @@
 		search.autofocus = true;
 		search.addEventListener('input', event => {
 			var q = search.value.toLowerCase();
-			document.querySelectorAll('tbody tr').forEach(tr => {
+			document.querySelectorAll('tbody > tr').forEach(tr => {
 				tr.hidden = q && !tr.textContent.toLowerCase().includes(q);
 			});
 		});


### PR DESCRIPTION
I think it would be better to keep the table header while searching the table.