### PR TITLE
avoid page break inside of rows

### DIFF
--- a/template.html
+++ b/template.html
@@ -60,6 +60,8 @@
 			a::after {
 				content: ' (' attr(href) ')';
 			}
+			table.print-friendly tr {
+				page-break-inside: avoid;
 		}
 	</style>
 </head>
@@ -81,7 +83,7 @@
 		<tbody>
 			<tr>
 				<td class="fake-td">
-					<table>
+					<table class="print-friendly">
 						<thead>
 							<tr>
 								{{{ thead }}}


### PR DESCRIPTION
I noticed that a page break occurs within rows in Firefox versions 102.0 and 103.0.2 when printing the table. This fixed the issue for me.

The page break does not occur in Google Chrome version 104.0.5112.81 and Microsoft Edge version 104.0.1293.54. But another issue occurred in these two browsers when printing the page: when columns Deutsch, Englisch, Französisch, Arabisch, Persisch and Türkisch were selected and the page was scaled to 100 % the footer jumped to the top of the table. Only at 100 %. I am not sure what happens here. Do you have an idea?