### PR TITLE
keep table headers fixed when scrolling down

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -25,6 +25,8 @@ DIR = {
 	'ar': 'rtl',
 	'fa': 'rtl',
 }
+TD_CLASS = 'real-td'
+TH_CLASS = 'real-th'
 
 
 locale.setlocale(locale.LC_ALL, '')
@@ -78,7 +80,7 @@ if __name__ == '__main__':
 	for lang, label in get_header(data):
 		_lang = html.escape(lang)
 		_label = html.escape(label)
-		thead += f'<th data-lang="{_lang}">{_label}</th>\n'
+		thead += f'<th class="{TH_CLASS}" data-lang="{_lang}">{_label}</th>\n'
 
 	tbody = ''
 	for row in get_rows(data):
@@ -87,7 +89,7 @@ if __name__ == '__main__':
 			_lang = html.escape(lang)
 			_label = html.escape(label)
 			_dir = html.escape(DIR.get(lang, 'ltr'))
-			tbody += f'<td lang="{_lang}" dir="{_dir}">{_label}</td>\n'
+			tbody += f'<td class="{TD_CLASS}" lang="{_lang}" dir="{_dir}">{_label}</td>\n'
 		tbody += '</tr>\n'
 
 	print(

--- a/generate.py
+++ b/generate.py
@@ -25,9 +25,6 @@ DIR = {
 	'ar': 'rtl',
 	'fa': 'rtl',
 }
-TD_CLASS = 'real-td'
-TH_CLASS = 'real-th'
-
 
 locale.setlocale(locale.LC_ALL, '')
 
@@ -80,7 +77,7 @@ if __name__ == '__main__':
 	for lang, label in get_header(data):
 		_lang = html.escape(lang)
 		_label = html.escape(label)
-		thead += f'<th class="{TH_CLASS}" data-lang="{_lang}">{_label}</th>\n'
+		thead += f'<th data-lang="{_lang}">{_label}</th>\n'
 
 	tbody = ''
 	for row in get_rows(data):
@@ -89,7 +86,7 @@ if __name__ == '__main__':
 			_lang = html.escape(lang)
 			_label = html.escape(label)
 			_dir = html.escape(DIR.get(lang, 'ltr'))
-			tbody += f'<td class="{TD_CLASS}" lang="{_lang}" dir="{_dir}">{_label}</td>\n'
+			tbody += f'<td lang="{_lang}" dir="{_dir}">{_label}</td>\n'
 		tbody += '</tr>\n'
 
 	print(

--- a/template.html
+++ b/template.html
@@ -27,24 +27,29 @@
 		img {
 			max-height: 5em;
 		}
-		table {
-			border-collapse: collapse;
+		.real-table {
 			border-spacing: 0;
+			border-top: 1px solid black;
+			border-right: 1px solid black;
 		}
-		td, th {
-			border: 1px solid black;
+		.real-td, 
+		.real-th {
+			border-bottom: 1px solid black;
+			border-left: 1px solid black;
 			padding: 0.2em 0.5em;
 			vertical-align: top;
+		}
+		.fake-table {
+			border-spacing: 0;
+		}
+		.fake-td {
+			padding: 0;
+			padding-bottom: 1em;
 		}
 		form {
 			display: flex;
 			gap: 1em;
 			margin-top: 1em;
-		}
-		.fake-td {
-			border: 0;
-			padding: 0;
-			padding-bottom: 1em;
 		}
 		.notes {
 			font-size: small;
@@ -62,11 +67,22 @@
 			}
 			table.print-friendly tr {
 				page-break-inside: avoid;
+			}
+			.real-table {
+				border-collapse: collapse;
+			}
+		}
+		@media screen and (min-height: 15rem) {
+			.real-thead {
+				background: white;
+				position: sticky;
+				top: 0;
+			}
 		}
 	</style>
 </head>
 <body>
-	<table>
+	<table class="fake-table">
 		<thead>
 			<tr>
 				<td class="fake-td">
@@ -83,8 +99,8 @@
 		<tbody>
 			<tr>
 				<td class="fake-td">
-					<table class="print-friendly">
-						<thead>
+					<table class="print-friendly real-table">
+						<thead class="real-thead">
 							<tr>
 								{{{ thead }}}
 							</tr>

--- a/template.html
+++ b/template.html
@@ -65,11 +65,11 @@
 			a::after {
 				content: ' (' attr(href) ')';
 			}
-			table.print-friendly tr {
-				page-break-inside: avoid;
-			}
 			.real-table {
 				border-collapse: collapse;
+			}
+			.real-table tr {
+				page-break-inside: avoid;
 			}
 		}
 		@media screen and (min-height: 15rem) {
@@ -99,7 +99,7 @@
 		<tbody>
 			<tr>
 				<td class="fake-td">
-					<table class="print-friendly real-table">
+					<table class="real-table">
 						<thead class="real-thead">
 							<tr>
 								{{{ thead }}}

--- a/template.html
+++ b/template.html
@@ -32,8 +32,8 @@
 			border-top: 1px solid black;
 			border-right: 1px solid black;
 		}
-		.real-td, 
-		.real-th {
+		.real-table td,
+		.real-table th {
 			border-bottom: 1px solid black;
 			border-left: 1px solid black;
 			padding: 0.2em 0.5em;
@@ -73,7 +73,7 @@
 			}
 		}
 		@media screen and (min-height: 15rem) {
-			.real-thead {
+			.real-table thead {
 				background: white;
 				position: sticky;
 				top: 0;
@@ -100,7 +100,7 @@
 			<tr>
 				<td class="fake-td">
 					<table class="real-table">
-						<thead class="real-thead">
+						<thead>
 							<tr>
 								{{{ thead }}}
 							</tr>

--- a/template.html
+++ b/template.html
@@ -28,14 +28,14 @@
 			max-height: 5em;
 		}
 		.real-table {
-			border-spacing: 0;
-			border-top: 1px solid black;
-			border-right: 1px solid black;
+			border-collapse: collapse;
+		}
+		.real-table tr {
+			page-break-inside: avoid;
 		}
 		.real-table td,
 		.real-table th {
-			border-bottom: 1px solid black;
-			border-left: 1px solid black;
+			border: 1px solid black;
 			padding: 0.2em 0.5em;
 			vertical-align: top;
 		}
@@ -65,14 +65,20 @@
 			a::after {
 				content: ' (' attr(href) ')';
 			}
-			.real-table {
-				border-collapse: collapse;
-			}
-			.real-table tr {
-				page-break-inside: avoid;
-			}
 		}
 		@media screen and (min-height: 15rem) {
+			/* borders need to be separated so that sticky thead has a border */
+			.real-table {
+				border-collapse: separate;
+				border-spacing: 0;
+				border-top: 1px solid black;
+				border-right: 1px solid black;
+			}
+			.real-table td,
+			.real-table th {
+				border-top: 0;
+				border-right: 0;
+			}
 			.real-table thead {
 				background: white;
 				position: sticky;


### PR DESCRIPTION
I'd like to keep the column headers visible while scrolling down the page. Do you think it is a good idea to work with sticky here?